### PR TITLE
Split cursor into reader and writer types

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,29 +11,29 @@ A simple iterator for packing/unpacking primitive c types to/from a provided buf
     /* A buffer to store packed data */
     uint8_t buf[6];
 
-    /* Construct a new cursor with the buffer we just defined */
-    struct cursor csr = cursor_new(buf, sizeof(buf));
+    /* Construct a new writer cursor with the buffer we just defined */
+    struct cursor_wtr wtr = cursor_wtr_new(buf, sizeof(buf));
 
     uint16_t written_u16 = 0x0123;
     uint32_t written_u32 = 0x456789AB;
 
     /* Write written_u16 to buf little-endian */
-    cursor_pack_le(&csr, written_u16);
+    cursor_pack_le(&wtr, written_u16);
 
     /* Write written_u32 to buf big-endian */
-    cursor_pack_be(&csr, written_u32);
+    cursor_pack_be(&wtr, written_u32);
 
-    /* Reset csr */
-    csr = cursor_new(buf, sizeof(buf));
+    /* Construct a reader cursor */
+    struct cursor_rdr rdr = cursor_rdr_new(buf, sizeof(buf));
 
     uint16_t read_u16 = 0;
     uint32_t read_u32 = 0;
 
     /* Read a packed little-endian uint16_t out of buf */
-    cursor_unpack_le(&csr, &read_u16);
+    cursor_unpack_le(&rdr, &read_u16);
 
     /* Read a packed big-endian uint32_t out of buf */
-    cursor_unpack_be(&csr, &read_u32);
+    cursor_unpack_be(&rdr, &read_u32);
 
     assert(read_u16 == written_u16);
     assert(read_u32 == written_u32);

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -14,7 +14,7 @@ main(int argc, char * argv[]) {
     uint8_t buf[42];
 
     /* Construct a new cursor with the buffer we just defined */
-    struct cursor csr = cursor_new(buf, sizeof(buf));
+    struct cursor_wtr wtr = cursor_wtr_new(buf, sizeof(buf));
 
     /* Primitives we'll pack into the buffer */
     uint8_t  packed_u8  = rand();
@@ -33,22 +33,22 @@ main(int argc, char * argv[]) {
      * `cursor_pack_be` is actually macro using c11's generic selector feature.
      * It dispatches to the correct cursor function call based on the primitive
      * type */
-    assert(cursor_pack_be(&csr, packed_u8) == cursor_res_ok);
-    assert(cursor_pack_le(&csr, packed_i8) == cursor_res_ok);
-    assert(cursor_pack_be(&csr, packed_u16) == cursor_res_ok);
-    assert(cursor_pack_le(&csr, packed_i16) == cursor_res_ok);
-    assert(cursor_pack_be(&csr, packed_u32) == cursor_res_ok);
-    assert(cursor_pack_le(&csr, packed_i32) == cursor_res_ok);
-    assert(cursor_pack_be(&csr, packed_u64) == cursor_res_ok);
-    assert(cursor_pack_le(&csr, packed_i64) == cursor_res_ok);
-    assert(cursor_pack_be(&csr, packed_f) == cursor_res_ok);
-    assert(cursor_pack_le(&csr, packed_d) == cursor_res_ok);
+    assert(cursor_pack_be(&wtr, packed_u8) == cursor_res_ok);
+    assert(cursor_pack_le(&wtr, packed_i8) == cursor_res_ok);
+    assert(cursor_pack_be(&wtr, packed_u16) == cursor_res_ok);
+    assert(cursor_pack_le(&wtr, packed_i16) == cursor_res_ok);
+    assert(cursor_pack_be(&wtr, packed_u32) == cursor_res_ok);
+    assert(cursor_pack_le(&wtr, packed_i32) == cursor_res_ok);
+    assert(cursor_pack_be(&wtr, packed_u64) == cursor_res_ok);
+    assert(cursor_pack_le(&wtr, packed_i64) == cursor_res_ok);
+    assert(cursor_pack_be(&wtr, packed_f) == cursor_res_ok);
+    assert(cursor_pack_le(&wtr, packed_d) == cursor_res_ok);
 
     /* Our buffer was sized to have no leftover space.
      * Let's verify that attempting another pack operation returns an error.
      * Note that we're explicitly calling `cursor_pack_le_u8` here, and not
      * using the type-generic `cursor_pack_le` macro */
-    assert(cursor_pack_le_u16(&csr, rand()) == cursor_res_err_buf_exhausted);
+    assert(cursor_pack_le_u16(&wtr, rand()) == cursor_res_err_buf_exhausted);
 
     /* We'll unpack our packed variables into these variables */
     uint8_t  unpacked_u8;
@@ -64,19 +64,19 @@ main(int argc, char * argv[]) {
 
     /* Reset the cursor.
      * `cursor_new` does not allocate so this is safe */
-    csr = cursor_new(buf, sizeof(buf));
+    struct cursor_rdr rdr = cursor_rdr_new(buf, sizeof(buf));
 
     /* Now unpack out of the buffer we packed into earlier  */
-    assert(cursor_unpack_be(&csr, &unpacked_u8) == cursor_res_ok);
-    assert(cursor_unpack_le(&csr, &unpacked_i8) == cursor_res_ok);
-    assert(cursor_unpack_be(&csr, &unpacked_u16) == cursor_res_ok);
-    assert(cursor_unpack_le(&csr, &unpacked_i16) == cursor_res_ok);
-    assert(cursor_unpack_be(&csr, &unpacked_u32) == cursor_res_ok);
-    assert(cursor_unpack_le(&csr, &unpacked_i32) == cursor_res_ok);
-    assert(cursor_unpack_be(&csr, &unpacked_u64) == cursor_res_ok);
-    assert(cursor_unpack_le(&csr, &unpacked_i64) == cursor_res_ok);
-    assert(cursor_unpack_be(&csr, &unpacked_f) == cursor_res_ok);
-    assert(cursor_unpack_le(&csr, &unpacked_d) == cursor_res_ok);
+    assert(cursor_unpack_be(&rdr, &unpacked_u8) == cursor_res_ok);
+    assert(cursor_unpack_le(&rdr, &unpacked_i8) == cursor_res_ok);
+    assert(cursor_unpack_be(&rdr, &unpacked_u16) == cursor_res_ok);
+    assert(cursor_unpack_le(&rdr, &unpacked_i16) == cursor_res_ok);
+    assert(cursor_unpack_be(&rdr, &unpacked_u32) == cursor_res_ok);
+    assert(cursor_unpack_le(&rdr, &unpacked_i32) == cursor_res_ok);
+    assert(cursor_unpack_be(&rdr, &unpacked_u64) == cursor_res_ok);
+    assert(cursor_unpack_le(&rdr, &unpacked_i64) == cursor_res_ok);
+    assert(cursor_unpack_be(&rdr, &unpacked_f) == cursor_res_ok);
+    assert(cursor_unpack_le(&rdr, &unpacked_d) == cursor_res_ok);
 
     /* Check the packed and unpacked variables for equality */
     assert(packed_u8 == unpacked_u8);

--- a/include/cursor/cursor.h
+++ b/include/cursor/cursor.h
@@ -8,11 +8,21 @@
 extern "C" {
 #endif
 
-/* A context for [de]serializing data from a buffer */
-struct cursor {
-    uint8_t * buf;
-    size_t    len;
-    size_t    pos;
+/* Common state for both reader and writer cursors. */
+struct cursor_state_ {
+    size_t len;
+    size_t pos;
+};
+/* A context for serializing data to a buffer */
+struct cursor_wtr {
+    struct cursor_state_ state;
+    uint8_t *            buf;
+};
+
+/* A context for deserializing data from a buffer */
+struct cursor_rdr {
+    struct cursor_state_ state;
+    uint8_t const *      buf;
 };
 
 enum cursor_res {
@@ -23,52 +33,58 @@ enum cursor_res {
 };
 
 /**
- * Creates and returns a new cursor object
+ * Creates and returns a writer cursor object
  */
-struct cursor
-cursor_new(void * buf, size_t buflen);
+struct cursor_wtr
+cursor_wtr_new(uint8_t * buf, size_t buflen);
+
+/**
+ * Creates and returns a writer cursor object
+ */
+struct cursor_rdr
+cursor_rdr_new(uint8_t const * buf, size_t buflen);
 
 size_t
-cursor_remaining(struct cursor const * csr);
+cursor_remaining(void const * csr);
 
 enum cursor_res
-cursor_take(struct cursor * csr, size_t n, uint8_t * dst);
+cursor_take(struct cursor_rdr * csr, size_t n, uint8_t * dst);
 
 size_t
-cursor_take_remaining(struct cursor * csr, uint8_t * dst);
+cursor_take_remaining(struct cursor_rdr * csr, uint8_t * dst);
 
 enum cursor_res
-cursor_put(struct cursor * csr, void const * src, size_t src_len);
+cursor_put(struct cursor_wtr * csr, void const * src, size_t src_len);
 
 enum cursor_res
-cursor_unpack_le_u8(struct cursor * csr, uint8_t * dst);
+cursor_unpack_le_u8(struct cursor_rdr * csr, uint8_t * dst);
 
 enum cursor_res
-cursor_unpack_le_i8(struct cursor * csr, int8_t * dst);
+cursor_unpack_le_i8(struct cursor_rdr * csr, int8_t * dst);
 
 enum cursor_res
-cursor_unpack_le_u16(struct cursor * csr, uint16_t * dst);
+cursor_unpack_le_u16(struct cursor_rdr * csr, uint16_t * dst);
 
 enum cursor_res
-cursor_unpack_le_i16(struct cursor * csr, int16_t * dst);
+cursor_unpack_le_i16(struct cursor_rdr * csr, int16_t * dst);
 
 enum cursor_res
-cursor_unpack_le_u32(struct cursor * csr, uint32_t * dst);
+cursor_unpack_le_u32(struct cursor_rdr * csr, uint32_t * dst);
 
 enum cursor_res
-cursor_unpack_le_i32(struct cursor * csr, int32_t * dst);
+cursor_unpack_le_i32(struct cursor_rdr * csr, int32_t * dst);
 
 enum cursor_res
-cursor_unpack_le_u64(struct cursor * csr, uint64_t * dst);
+cursor_unpack_le_u64(struct cursor_rdr * csr, uint64_t * dst);
 
 enum cursor_res
-cursor_unpack_le_i64(struct cursor * csr, int64_t * dst);
+cursor_unpack_le_i64(struct cursor_rdr * csr, int64_t * dst);
 
 enum cursor_res
-cursor_unpack_le_f(struct cursor * csr, float * dst);
+cursor_unpack_le_f(struct cursor_rdr * csr, float * dst);
 
 enum cursor_res
-cursor_unpack_le_d(struct cursor * csr, double * dst);
+cursor_unpack_le_d(struct cursor_rdr * csr, double * dst);
 
 #define cursor_unpack_le(_CSR, _DST)                                           \
     _Generic((_DST),                                                           \
@@ -85,34 +101,34 @@ cursor_unpack_le_d(struct cursor * csr, double * dst);
              )(_CSR, _DST)
 
 enum cursor_res
-cursor_unpack_be_u8(struct cursor * csr, uint8_t * dst);
+cursor_unpack_be_u8(struct cursor_rdr * csr, uint8_t * dst);
 
 enum cursor_res
-cursor_unpack_be_i8(struct cursor * csr, int8_t * dst);
+cursor_unpack_be_i8(struct cursor_rdr * csr, int8_t * dst);
 
 enum cursor_res
-cursor_unpack_be_u16(struct cursor * csr, uint16_t * dst);
+cursor_unpack_be_u16(struct cursor_rdr * csr, uint16_t * dst);
 
 enum cursor_res
-cursor_unpack_be_i16(struct cursor * csr, int16_t * dst);
+cursor_unpack_be_i16(struct cursor_rdr * csr, int16_t * dst);
 
 enum cursor_res
-cursor_unpack_be_u32(struct cursor * csr, uint32_t * dst);
+cursor_unpack_be_u32(struct cursor_rdr * csr, uint32_t * dst);
 
 enum cursor_res
-cursor_unpack_be_i32(struct cursor * csr, int32_t * dst);
+cursor_unpack_be_i32(struct cursor_rdr * csr, int32_t * dst);
 
 enum cursor_res
-cursor_unpack_be_u64(struct cursor * csr, uint64_t * dst);
+cursor_unpack_be_u64(struct cursor_rdr * csr, uint64_t * dst);
 
 enum cursor_res
-cursor_unpack_be_i64(struct cursor * csr, int64_t * dst);
+cursor_unpack_be_i64(struct cursor_rdr * csr, int64_t * dst);
 
 enum cursor_res
-cursor_unpack_be_f(struct cursor * csr, float * dst);
+cursor_unpack_be_f(struct cursor_rdr * csr, float * dst);
 
 enum cursor_res
-cursor_unpack_be_d(struct cursor * csr, double * dst);
+cursor_unpack_be_d(struct cursor_rdr * csr, double * dst);
 
 #define cursor_unpack_be(_CSR, _DST)                                           \
     _Generic((_DST),                                                           \
@@ -129,34 +145,34 @@ cursor_unpack_be_d(struct cursor * csr, double * dst);
              )(_CSR, _DST)
 
 enum cursor_res
-cursor_pack_le_u8(struct cursor * csr, uint8_t val);
+cursor_pack_le_u8(struct cursor_wtr * csr, uint8_t val);
 
 enum cursor_res
-cursor_pack_le_i8(struct cursor * csr, int8_t val);
+cursor_pack_le_i8(struct cursor_wtr * csr, int8_t val);
 
 enum cursor_res
-cursor_pack_le_u16(struct cursor * csr, uint16_t val);
+cursor_pack_le_u16(struct cursor_wtr * csr, uint16_t val);
 
 enum cursor_res
-cursor_pack_le_i16(struct cursor * csr, int16_t val);
+cursor_pack_le_i16(struct cursor_wtr * csr, int16_t val);
 
 enum cursor_res
-cursor_pack_le_u32(struct cursor * csr, uint32_t val);
+cursor_pack_le_u32(struct cursor_wtr * csr, uint32_t val);
 
 enum cursor_res
-cursor_pack_le_i32(struct cursor * csr, int32_t val);
+cursor_pack_le_i32(struct cursor_wtr * csr, int32_t val);
 
 enum cursor_res
-cursor_pack_le_u64(struct cursor * csr, uint64_t val);
+cursor_pack_le_u64(struct cursor_wtr * csr, uint64_t val);
 
 enum cursor_res
-cursor_pack_le_i64(struct cursor * csr, int64_t val);
+cursor_pack_le_i64(struct cursor_wtr * csr, int64_t val);
 
 enum cursor_res
-cursor_pack_le_f(struct cursor * csr, float val);
+cursor_pack_le_f(struct cursor_wtr * csr, float val);
 
 enum cursor_res
-cursor_pack_le_d(struct cursor * csr, double val);
+cursor_pack_le_d(struct cursor_wtr * csr, double val);
 
 #define cursor_pack_le(_CSR, _DST)                                             \
     _Generic((_DST), uint8_t                                                   \
@@ -172,34 +188,34 @@ cursor_pack_le_d(struct cursor * csr, double val);
              : cursor_pack_le_d)(_CSR, _DST)
 
 enum cursor_res
-cursor_pack_be_u8(struct cursor * csr, uint8_t val);
+cursor_pack_be_u8(struct cursor_wtr * csr, uint8_t val);
 
 enum cursor_res
-cursor_pack_be_i8(struct cursor * csr, int8_t val);
+cursor_pack_be_i8(struct cursor_wtr * csr, int8_t val);
 
 enum cursor_res
-cursor_pack_be_u16(struct cursor * csr, uint16_t val);
+cursor_pack_be_u16(struct cursor_wtr * csr, uint16_t val);
 
 enum cursor_res
-cursor_pack_be_i16(struct cursor * csr, int16_t val);
+cursor_pack_be_i16(struct cursor_wtr * csr, int16_t val);
 
 enum cursor_res
-cursor_pack_be_u32(struct cursor * csr, uint32_t val);
+cursor_pack_be_u32(struct cursor_wtr * csr, uint32_t val);
 
 enum cursor_res
-cursor_pack_be_i32(struct cursor * csr, int32_t val);
+cursor_pack_be_i32(struct cursor_wtr * csr, int32_t val);
 
 enum cursor_res
-cursor_pack_be_u64(struct cursor * csr, uint64_t val);
+cursor_pack_be_u64(struct cursor_wtr * csr, uint64_t val);
 
 enum cursor_res
-cursor_pack_be_i64(struct cursor * csr, int64_t val);
+cursor_pack_be_i64(struct cursor_wtr * csr, int64_t val);
 
 enum cursor_res
-cursor_pack_be_f(struct cursor * csr, float val);
+cursor_pack_be_f(struct cursor_wtr * csr, float val);
 
 enum cursor_res
-cursor_pack_be_d(struct cursor * csr, double val);
+cursor_pack_be_d(struct cursor_wtr * csr, double val);
 
 #define cursor_pack_be(_CSR, _DST)                                             \
     _Generic((_DST), uint8_t                                                   \

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -3,55 +3,63 @@
 #include <cursor/packing.h>
 #include <string.h>
 
-struct cursor
-cursor_new(void * buf, size_t buflen) {
+struct cursor_wtr
+cursor_wtr_new(uint8_t * buf, size_t buflen) {
     assert(buf);
-    return (struct cursor){
-        .buf = buf,
-        .len = buflen,
-        .pos = 0,
+    return (struct cursor_wtr){
+        .buf   = buf,
+        .state = {.len = buflen, .pos = 0},
+    };
+}
+
+struct cursor_rdr
+cursor_rdr_new(uint8_t const * buf, size_t buflen) {
+    assert(buf);
+    return (struct cursor_rdr){
+        .buf   = buf,
+        .state = {.len = buflen, .pos = 0},
     };
 }
 
 /* Check that buffer has enough bytes left to unpack the desired type out */
 #define SIZE_CHECK(_CSR, _PRIM_TYPE)                                           \
     do {                                                                       \
-        if ((_CSR->pos + sizeof(_PRIM_TYPE)) > _CSR->len) {                    \
+        if ((_CSR->state.pos + sizeof(_PRIM_TYPE)) > _CSR->state.len) {        \
             return cursor_res_err_buf_exhausted;                               \
         }                                                                      \
     } while (0)
 
 #define INC_POS(_CSR, _PRIM_TYPE)                                              \
     do {                                                                       \
-        _CSR->pos += sizeof(_PRIM_TYPE);                                       \
+        _CSR->state.pos += sizeof(_PRIM_TYPE);                                 \
     } while (0)
 
 #define GENERATE(_PRIM_TYPE, _SHORT_NAME)                                      \
-    enum cursor_res cursor_unpack_le_##_SHORT_NAME(struct cursor * csr,        \
-                                                   _PRIM_TYPE *    dst) {         \
+    enum cursor_res cursor_unpack_le_##_SHORT_NAME(struct cursor_rdr * csr,    \
+                                                   _PRIM_TYPE *        dst) {         \
         SIZE_CHECK(csr, *dst);                                                 \
-        unpack_le_##_SHORT_NAME(dst, &csr->buf[csr->pos]);                     \
+        unpack_le_##_SHORT_NAME(dst, &csr->buf[csr->state.pos]);               \
         INC_POS(csr, *dst);                                                    \
         return cursor_res_ok;                                                  \
     }                                                                          \
-    enum cursor_res cursor_pack_le_##_SHORT_NAME(struct cursor * csr,          \
-                                                 _PRIM_TYPE      val) {             \
+    enum cursor_res cursor_pack_le_##_SHORT_NAME(struct cursor_wtr * csr,      \
+                                                 _PRIM_TYPE          val) {             \
         SIZE_CHECK(csr, val);                                                  \
-        pack_le_##_SHORT_NAME(&csr->buf[csr->pos], val);                       \
+        pack_le_##_SHORT_NAME(&csr->buf[csr->state.pos], val);                 \
         INC_POS(csr, val);                                                     \
         return cursor_res_ok;                                                  \
     }                                                                          \
-    enum cursor_res cursor_unpack_be_##_SHORT_NAME(struct cursor * csr,        \
-                                                   _PRIM_TYPE *    dst) {         \
+    enum cursor_res cursor_unpack_be_##_SHORT_NAME(struct cursor_rdr * csr,    \
+                                                   _PRIM_TYPE *        dst) {         \
         SIZE_CHECK(csr, *dst);                                                 \
-        unpack_be_##_SHORT_NAME(dst, &csr->buf[csr->pos]);                     \
+        unpack_be_##_SHORT_NAME(dst, &csr->buf[csr->state.pos]);               \
         INC_POS(csr, *dst);                                                    \
         return cursor_res_ok;                                                  \
     }                                                                          \
-    enum cursor_res cursor_pack_be_##_SHORT_NAME(struct cursor * csr,          \
-                                                 _PRIM_TYPE      val) {             \
+    enum cursor_res cursor_pack_be_##_SHORT_NAME(struct cursor_wtr * csr,      \
+                                                 _PRIM_TYPE          val) {             \
         SIZE_CHECK(csr, val);                                                  \
-        pack_be_##_SHORT_NAME(&csr->buf[csr->pos], val);                       \
+        pack_be_##_SHORT_NAME(&csr->buf[csr->state.pos], val);                 \
         INC_POS(csr, val);                                                     \
         return cursor_res_ok;                                                  \
     }
@@ -69,22 +77,23 @@ GENERATE(float, f)
 GENERATE(double, d)
 
 enum cursor_res
-cursor_take(struct cursor * csr, size_t n, uint8_t * dst) {
-    if (csr->pos + n > csr->len) {
+cursor_take(struct cursor_rdr * csr, size_t n, uint8_t * dst) {
+    if (csr->state.pos + n > csr->state.len) {
         return cursor_res_err_buf_exhausted;
     }
-    memmove(dst, csr->buf + csr->pos, n);
-    csr->pos += n;
+    memmove(dst, csr->buf + csr->state.pos, n);
+    csr->state.pos += n;
     return cursor_res_ok;
 }
 
 size_t
-cursor_remaining(struct cursor const * csr) {
-    return csr->len - csr->pos;
+cursor_remaining(void const * csr) {
+    struct cursor_state_ const * state = csr;
+    return state->len - state->pos;
 }
 
 size_t
-cursor_take_remaining(struct cursor * csr, uint8_t * dst) {
+cursor_take_remaining(struct cursor_rdr * csr, uint8_t * dst) {
     size_t          remaining = cursor_remaining(csr);
     enum cursor_res res       = cursor_take(csr, remaining, dst);
     assert(cursor_res_ok == res);
@@ -94,11 +103,11 @@ cursor_take_remaining(struct cursor * csr, uint8_t * dst) {
 }
 
 enum cursor_res
-cursor_put(struct cursor * csr, void const * src, size_t src_len) {
+cursor_put(struct cursor_wtr * csr, void const * src, size_t src_len) {
     if (cursor_remaining(csr) < src_len) {
         return cursor_res_err_buf_exhausted;
     }
-    memcpy(&csr->buf[csr->pos], src, src_len);
-    csr->pos += src_len;
+    memcpy(&csr->buf[csr->state.pos], src, src_len);
+    csr->state.pos += src_len;
     return cursor_res_ok;
 }


### PR DESCRIPTION
Reading is currently not const-correct. Splitting cursors into read and write types allows reading from a const buffer.